### PR TITLE
レスポンスから商品名を抽出する関数の実装

### DIFF
--- a/backend/src/analyze.ts
+++ b/backend/src/analyze.ts
@@ -1,0 +1,25 @@
+import { ApiVisionResponse } from "./apitypes";
+
+export const getNecessaryInfo = (response: ApiVisionResponse): string[] => {
+  const allText = response.fullTextAnnotation.text;
+  const listTexts = allText.split("\n");
+  const reTime = new RegExp(/\d+:\d+/);
+  const indexOfTime = listTexts.findIndex((element) => {
+    return reTime.test(element);
+  });
+  const reSum = new RegExp(/小計/);
+  const indexOfSum = listTexts.findIndex((element) => {
+    return reSum.test(element);
+  });
+  const shoppingContents = listTexts.slice(indexOfTime + 1, indexOfSum);
+  const dropNumbers = new RegExp(/^\D+$/);
+  let items: string[] = [];
+  for (const eachItem of shoppingContents) {
+    const itemSplitted = eachItem.split(" ");
+    for (const item of itemSplitted) {
+      if (dropNumbers.test(item)) items.push(item);
+    }
+  }
+
+  return items;
+};

--- a/backend/src/apitypes.d.ts
+++ b/backend/src/apitypes.d.ts
@@ -1,0 +1,21 @@
+export type ApiVisionResponse = {
+  faceAnnotations?: any[];
+  landmarkAnnotations?: any[];
+  logoAnnotations?: any[];
+  labelAnnotations?: any[];
+  textAnnotations?: any[];
+  localizedObjectAnnotations?: any[];
+  safeSearchAnnotation?: any;
+  imagePropertiesAnnotation?: any;
+  error?: any;
+  cropHintsAnnotation?: any;
+  fullTextAnnotation?: fullTextAnnotation;
+  webDetection?: any;
+  productSearchResults?: any;
+  context?: any;
+};
+
+type fullTextAnnotation = {
+  pages?: object[];
+  text?: string;
+};

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -9,8 +9,8 @@ const main = (): void => {
     },
   }; // TODO remove this sample
   const requestData = sampleRequest; // TODO do sth for requested data
-  const imageName = requestData.data.name;
-  const result = triggerOcr(originalImageFolderPath + imageName);
+  const imageName: string = requestData.data.name;
+  const result: string[] = triggerOcr(originalImageFolderPath + imageName);
   console.log(result);
   return;
 };

--- a/backend/src/ocr.ts
+++ b/backend/src/ocr.ts
@@ -1,15 +1,17 @@
 import * as fs from "fs";
 import { requestGoogleVisionAPI } from "./requests";
+import { getNecessaryInfo } from "./analyze";
+import type { ApiVisionResponse } from "./apitypes";
 
-export const triggerOcr = (imagePath: string): object => {
+export const triggerOcr = (imagePath: string): string[] => {
   // get image from imagePath
-  //   const response: object = requestGoogleVisionAPI(imagePath);
+  //   const response: ApiVisionResponse = requestGoogleVisionAPI(imagePath);
   // mock response
-  const response: object = JSON.parse(
+  const response: ApiVisionResponse = JSON.parse(
     fs.readFileSync("textdetection_result_saved.json", "utf8")
   );
-  console.log(response);
-  const result = response;
+  // console.log(response);
+  const result = getNecessaryInfo(response);
   return result;
 };
 

--- a/backend/src/requests.ts
+++ b/backend/src/requests.ts
@@ -1,9 +1,11 @@
 import fs from "fs";
 import vision from "@google-cloud/vision";
+// import type IAnnotateImageResponse from "@google-cloud/vision";
+import type { ApiVisionResponse } from "./apitypes";
 
 export const requestGoogleVisionAPI = async (
   imagepath: string
-): Promise<object> => {
+): Promise<ApiVisionResponse> => {
   const client = new vision.ImageAnnotatorClient();
   const fileName = imagepath; // TODO do sth if needed
   // Performs text detection on the local file


### PR DESCRIPTION
<!--
PR作成時に気をつけること
- [ ] わかりやすいタイトルをつけた
- [ ] 変更は十分に小さい
- [ ] 変更ファイルを再度確認した
- [ ] PRのpreviewを確認した
-->

# 目的・背景

<!-- ticketやissueのリンクを追加/PRを行う目的か背景を入力 -->

ticket: closes #16 

# 概要
Vision API のレスポンスからテキストを抽出し、商品名と思われる部分だけを返す関数を実装した。
レスポンスの中に個々の商品の価格が含まれていなかったので、商品名だけ取るようにした

# 変更によって期待される結果
データとして結果を保存する部分の実装が可能になる。

